### PR TITLE
Keep trailing "/" in group path when navigating back

### DIFF
--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -107,7 +107,8 @@
 (define-derived-mode keepass-mode tabulated-list-mode "KeePass"
   "KeePass mode for interacting with the KeePass DB. \\{keepass-mode-map}."
   (setq-local keepass-mode-db buffer-file-truename)
-  (setq-local keepass-mode-password (keepass-mode-ask-password))
+  (when (zerop (length keepass-mode-password))
+    (setq-local keepass-mode-password (keepass-mode-ask-password)))
   (setq-local keepass-mode-group-path "")
   (keepass-mode-open))
 

--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -46,7 +46,7 @@
 (defun keepass-mode-back ()
   "Navigate back in group tree."
   (interactive)
-  (keepass-mode-update-group-path (mapconcat #'identity (butlast (split-string keepass-mode-group-path "/" t) 1) "/"))
+  (keepass-mode-update-group-path (replace-regexp-in-string "[^/]*/?$" "" keepass-mode-group-path))
   (keepass-mode-open))
 
 (defun keepass-mode-copy (field)

--- a/tests/test-keepass-mode.el
+++ b/tests/test-keepass-mode.el
@@ -29,8 +29,8 @@
 
 (require 'keepass-mode)
 
-(setq keepass-mode-password "test")
-(setq keepass-mode-db "tests/fixtures/test.kdbx")
+(setq-default keepass-mode-password "test")
+(setq-default keepass-mode-db "tests/fixtures/test.kdbx")
 
 (describe "keepass-mode-get-URL"
           (it "returns the URL for an entry"
@@ -73,5 +73,17 @@
               (expect (keepass-mode-get-entry "Internet/Some site")
                       :to-equal
                       "Title: Some site\nUserName: username\nPassword: PROTECTED\nURL: https://somesite.com\nNotes: \n")))
+
+(describe "keepass-mode-back in a sub-group"
+          (it "returns the parent-group"
+              (find-file keepass-mode-db)
+              (search-forward-regexp "^SSH Keys")
+              (keepass-mode-select)
+              (search-forward-regexp "^Servers")
+              (keepass-mode-select)
+              (keepass-mode-back)
+              (expect keepass-mode-group-path
+                      :to-equal
+                      "SSH Keys/")))
 
 ;;; test-keepass-mode.el ends here


### PR DESCRIPTION
This avoids invalid groups paths when navigating forward, backward and
forward again.

Fixes #13