### PR TITLE
Egrep, font-lock, recursive list, and do not use password on command line.

### DIFF
--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -121,7 +121,8 @@ large KeePass database file."
 
 ;;;###autoload
 (define-derived-mode keepass-mode tabulated-list-mode "KeePass"
-  "KeePass mode for interacting with the KeePass DB. \\{keepass-mode-map}."
+  "KeePass mode for interacting with the KeePass DB.
+\\{keepass-mode-map}."
   (setq-local keepass-mode-db buffer-file-truename)
   (when (zerop (length keepass-mode-password))
     (setq-local keepass-mode-password (keepass-mode-ask-password)))

--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -29,6 +29,22 @@
 
 ;;; Code:
 
+(defgroup keepass nil
+  "KeePass/KeePassXC integration with Emacs."
+  :group 'convenience
+  :tag "keepass-mode"
+  :prefix "keepass-mode-")
+
+(defcustom keepass-mode-ls-recursive t
+  "Should list entries recursively?
+If nil, it will only show the first level of entries and folders.
+
+Tip: Recursive list may be useful when searching for a key in a buffer with
+\\[isearch-forward] (command `isearch-forward').  However, it may be too slow with a
+large KeePass database file."
+  :type 'boolean
+  :group 'keepass)
+
 (defvar-local keepass-mode-db "")
 (defvar-local keepass-mode-password "")
 (defvar-local keepass-mode-group-path "")
@@ -121,7 +137,11 @@
 
 (defun keepass-mode-get-entries (group)
   "Get entry list for GROUP."
-  (nbutlast (split-string (shell-command-to-string (keepass-mode-command (keepass-mode-quote-unless-empty group) "ls")) "\n") 1))
+  (nbutlast (split-string (shell-command-to-string
+                           (keepass-mode-command (keepass-mode-quote-unless-empty group)
+                                                 (if keepass-mode-ls-recursive
+                                                     "ls -R -f"
+                                                   "ls"))) "\n") 1))
 
 (defun keepass-mode-concat-group-path (group)
   "Concat GROUP and group path."

--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -119,10 +119,20 @@ large KeePass database file."
     (define-key map (kbd "c") 'keepass-mode-copy-password)
    map))
 
+(defface keepass-mode-font-lock-directory
+  '((t (:inherit dired-directory)))
+  "Face used for directory entries."
+  :group 'keepass)
+
+(defconst keepass-mode-font-lock-keywords
+  '(("^.*/" (0 'keepass-mode-font-lock-directory t)))
+  "Font-lock keywords for `keepass-mode'.")
+
 ;;;###autoload
 (define-derived-mode keepass-mode tabulated-list-mode "KeePass"
   "KeePass mode for interacting with the KeePass DB.
 \\{keepass-mode-map}."
+  (setq-local font-lock-defaults '(keepass-mode-font-lock-keywords nil t))
   (setq-local keepass-mode-db buffer-file-truename)
   (when (zerop (length keepass-mode-password))
     (setq-local keepass-mode-password (keepass-mode-ask-password)))

--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -143,7 +143,7 @@
   "Generate KeePass COMMAND to run, on GROUP."
   (format "echo %s | \
            keepassxc-cli %s %s %s 2>&1 | \
-           egrep -v '[Insert|Enter] password to unlock %s'"
+           grep -E -v '[Insert|Enter] password to unlock %s'"
           (shell-quote-argument keepass-mode-password)
           command
           keepass-mode-db


### PR DESCRIPTION
Hi! 👋🏽 

The egrep tool is marked as "obsolescent" from grep 3.11 (or some earlier versions) . This update changes egrep with the suggested `grep -E`. 

I added the recursive list parameter (`keepassxc-cli -R -f FILE`). Then, the user can see all entries at once, and use Emacs features such as highlighting, isearch, etc. to search. If the user do not want to use the recursive feature, a customization variable was also added to change it to the non-recursive as it was before these commits.

A font-lock was added to highlight directories paths. This makes the entry list a little more readable (I think 🤔 ).

Hope this is useful!
Cheers!

Added: The commit [cf94171](https://github.com/ifosch/keepass-mode/pull/22/commits/cf94171693b3d5365f676ae6dc6884ffe739075f) fix issue #21