### PR TITLE
Use grep instead of egrep

### DIFF
--- a/keepass-mode.el
+++ b/keepass-mode.el
@@ -143,7 +143,7 @@
   "Generate KeePass COMMAND to run, on GROUP."
   (format "echo %s | \
            keepassxc-cli %s %s %s 2>&1 | \
-           egrep -v '[Insert|Enter] password to unlock %s'"
+           grep -vE '[Insert|Enter] password to unlock %s'"
           (shell-quote-argument keepass-mode-password)
           command
           keepass-mode-db


### PR DESCRIPTION
This is to remove this warning

```
egrep: warning: egrep is obsolescent; using grep -E
```